### PR TITLE
[REACTBOIL-18] Update base font-size to use rem units in base 10

### DIFF
--- a/src/App.styles.ts
+++ b/src/App.styles.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const globalStyles = css`
+  html {
+    font-size: 62.5%;
+  }
+`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,25 @@
 import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
-import { ThemeProvider } from '@emotion/react';
+import { Global, ThemeProvider } from '@emotion/react';
 
 import AuthRouter from 'features/common/components/AuthRouter';
 import i18n from 'locales';
 import theme from 'theme';
 
+import { globalStyles } from 'App.styles';
+
 function App() {
   return (
-    <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <BrowserRouter>
-          <AuthRouter />
-        </BrowserRouter>
-      </I18nextProvider>
-    </ThemeProvider>
+    <>
+      <Global styles={globalStyles} />
+      <ThemeProvider theme={theme}>
+        <I18nextProvider i18n={i18n}>
+          <BrowserRouter>
+            <AuthRouter />
+          </BrowserRouter>
+        </I18nextProvider>
+      </ThemeProvider>
+    </>
   );
 }
 

--- a/src/features/Home/Home.styles.ts
+++ b/src/features/Home/Home.styles.ts
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 const HomeWrapper = styled.div`
   margin-top: 20px;
   color: ${({ theme }) => theme.color.indigo200};
+  font-size: 2rem;
 `;
 
 export default HomeWrapper;

--- a/src/features/Home/Home.styles.ts
+++ b/src/features/Home/Home.styles.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 const HomeWrapper = styled.div`
-  margin-top: 20px;
+  margin-top: 2rem;
   color: ${({ theme }) => theme.color.indigo200};
   font-size: 2rem;
 `;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,16 +7,16 @@ const theme: Theme = {
     base: '0.25rem',
     md: '0.375rem',
     lg: '0.5rem',
-    full: '9999px',
+    full: '999rem',
   },
   boxShadow: {
-    base: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+    base: '0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.1), 0 0.1rem 0.2rem 0 rgba(0, 0, 0, 0.06)',
     darkMd:
-      '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+      '0 0.4rem 0.6rem -0.1rem rgba(0, 0, 0, 0.1), 0 0.2rem 0.4rem -0.1rem rgba(0, 0, 0, 0.06)',
     darkLg:
-      '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+      '0 1rem 1.5rem -0.3rem rgba(0, 0, 0, 0.1), 0 0.4rem 0.6rem -0.2rem rgba(0, 0, 0, 0.05)',
     darkXl:
-      '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
+      '0 2rem 2.5rem -0.5rem rgba(0, 0, 0, 0.1), 0 1rem 1rem -0.5rem rgba(0, 0, 0, 0.04)',
     indigo: '0 0 1.5rem 0.1rem rgba(102, 126, 234, 0.6)',
     none: 'none',
   },


### PR DESCRIPTION
### :link: Board reference:

[Configurar root font size para usar rem units en base 10](https://loopstudio.atlassian.net/browse/REACTBOIL-18)

---

### :page_facing_up: Description

_This PR updates the base font size with the objective of using rem units in base 10, so that `1rem` equals `10px` (instead of 16px) without having to do complex conversions._

---

### :white_check_mark: Tasks:

- Configured `html` base `font-size`.
- Updated `Home` component font size.

---

### :pushpin: Notes:

- Note that this update will probably enforce the developers to use `rem` units for everything. If you mix `px` and `rem` you will get inconsistent results if the end user of the app sets the device size configuration to any value different from the default one.
- I added a `Global` styles component from `emotion`. We could probably add some global styles that are usually useful for most apps (like `height` for the root or `text-rendering` config).

---

### :play_or_pause_button: Demo:

Demo of how a font of size set to `2rem` if effectively equal to `20px` (so `1rem` = `10px`)

https://www.loom.com/share/09898b6b7e4b4be298b9aedc60d7f01a